### PR TITLE
Fix curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The first step is creating a Connect Token. This is an extra security measure th
 You can obtain a Connect Token by making the following request.
 
 ```
-curl --request POST 'http://api.pelm.com/auth/connect-token' \
+curl --request POST 'https://api.pelm.com/auth/connect-token' \
 --header 'client_id: YOUR_CLIENT_ID' \
 --header 'client_secret: YOUR_CLIENT_SECRET' \
 --form 'user_id="USER_ID"'


### PR DESCRIPTION
[Docs](https://docs.pelm.com/reference/getting-started#connect-token) correctly claim `https`, but the readme incorrectly claims `http`.